### PR TITLE
Updated to use text-embedding-3-large

### DIFF
--- a/feat.api/Services/SearchService.cs
+++ b/feat.api/Services/SearchService.cs
@@ -60,7 +60,7 @@ public class SearchService: ISearchService
         Uri embeddingsEndpoint = new Uri(_azureOptions.OpenAIEndpoint);
         AzureKeyCredential openAiCredential = new AzureKeyCredential(_azureOptions.OpenAIKey);
         _openAiClient = new AzureOpenAIClient(embeddingsEndpoint, openAiCredential);
-        _embeddingClient = _openAiClient.GetEmbeddingClient("text-embedding-ada-002");
+        _embeddingClient = _openAiClient.GetEmbeddingClient("text-embedding-3-large");
 
         // Create our http client for geo lookups
         _httpClientRepository = httpClientRepository;

--- a/feat.api/appsettings.Development.json
+++ b/feat.api/appsettings.Development.json
@@ -8,7 +8,7 @@
   "Azure": {
     "OpenAIEndpoint": "https://pp-api.education.gov.uk",
     "AISearchURL": "https://devsearchindexfinda.search.windows.net",
-    "AISearchIndex": "testfindi"
+    "AISearchIndex": "testfindj"
   }
 
 }


### PR DESCRIPTION
# What changed?
Updated the search service to use text-embedding-3 for the new index H

# Why?
The ADA-002 embedding is being retired early next year, so this allows us to get ahead of the curve